### PR TITLE
First pass downloading Dockerfile specified in devfile

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -29,6 +29,7 @@ type Storage struct {
 // BuildParameters is a struct containing the parameters to be used when building the image for a devfile component
 type BuildParameters struct {
 	Path            string                  // Path refers to the parent folder containing the source code to push up to a component
+	DockerfilePath  string                  // DockerfilePath is the path to the Dockerfile downloaded, if one was provided by the devfile
 	EnvSpecificInfo envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
 	Tag             string                  // Tag refers to the image tag of the image being built
 	IgnoredFiles    []string                // IgnoredFiles is the list of files to not push up to a component

--- a/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
+++ b/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
@@ -848,6 +848,14 @@ const JsonSchema200 = `{
 		  "name": {
 			"type": "string",
 			"description": "Optional devfile name"
+		  },
+		  "dockerfile": {
+			  "type":"string",
+			  "description": "Optional URL to remote Dockerfile"
+		  },
+		  "deployment-manifest":  {
+			  "type":"string",
+			  "description": "Optional URL to remote Deployment Manifest"
 		  }
 		}
 	  },

--- a/pkg/devfile/parser/data/common/types.go
+++ b/pkg/devfile/parser/data/common/types.go
@@ -56,6 +56,12 @@ type DevfileMetadata struct {
 
 	// Version Optional semver-compatible version
 	Version string `json:"version,omitempty"`
+
+	// Dockerfile optional URL to remote Dockerfile
+	Dockerfile string `json:"dockerfile,omitempty"`
+
+	// Manifest optional URL to remote Deployment Manifest
+	Manifest string `json:"deployment-manifest,omitempty"`
 }
 
 // DevfileCommand command specified in devfile

--- a/pkg/odo/cli/component/deploy.go
+++ b/pkg/odo/cli/component/deploy.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"path/filepath"
 
+	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/envinfo"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -64,6 +66,19 @@ func (do *DeployOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (do *DeployOptions) Run() (err error) {
+	devObj, err := devfileParser.Parse(do.DevfilePath)
+	if err != nil {
+		return err
+	}
+	metadata := devObj.Data.GetMetadata()
+	dockerfileURL := metadata.Dockerfile
+
+	// TODO: check for Dockerfile present
+	err = util.DownloadFile(dockerfileURL, "Dockerfile")
+	if err != nil {
+		return err
+	}
+
 	// TODO:
 	//    - Parse devfile and extract Dockerfile and manifest information
 	//    - Pull dockerfile into memory

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -140,6 +140,7 @@ func (do *DeployOptions) DevfileBuild() (err error) {
 
 	buildParams := common.BuildParameters{
 		Path:            do.sourcePath,
+		DockerfilePath:  do.DockerfilePath,
 		Tag:             do.tag,
 		EnvSpecificInfo: *do.EnvSpecificInfo,
 	}
@@ -159,7 +160,7 @@ func (do *DeployOptions) DevfileBuild() (err error) {
 	}
 
 	log.Infof("\nBuilding devfile component %s", componentName)
-	log.Success("Changes successfully build image for component")
+	log.Success("Changes successfully built image for component")
 
 	return nil
 }

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -47,6 +47,11 @@ func (a Adapter) SyncFilesBuild(buildParameters common.BuildParameters, compInfo
 	// run the indexer and find the modified/added/deleted/renamed files
 	files, _, err := util.RunIndexer(buildParameters.Path, absIgnoreRules)
 
+	// We will also need to copy the dockerfile if we are using one specified in the devfile
+	if buildParameters.DockerfilePath != "" {
+		files = append(files, ".odo/Dockerfile")
+	}
+
 	if len(files) > 0 {
 		klog.V(4).Infof("Copying files %s to pod", strings.Join(files, " "))
 		err = CopyFile(a.Client, buildParameters.Path, compInfo, syncFolder, files, absIgnoreRules)

--- a/tests/examples/source/devfilesV2/nodejs/devfile.yaml
+++ b/tests/examples/source/devfilesV2/nodejs/devfile.yaml
@@ -1,6 +1,7 @@
 schemaVersion: "2.0.0"
 metadata:
   name: test-devfile
+  dockerfile: "https://raw.githubusercontent.com/neeraj-laad/nodejs-stack-registry/build-deploy/devfiles/nodejs-basic/build/Dockerfile"
 projects:
   - name: nodejs-web-app
     git: 


### PR DESCRIPTION
Currently if the devfile passed contains a Dockerfile field within the manifest:
 - Check if user has Dockerfile, and warn them it's being overridden by the devfile Dockerfile 
 - Download the devfile specified Dockerfile to the .odo folder
 - Run the build with the Dockerfile
 - Delete the .odo Dockerfile

TODO:
 - Download into memory rather than onto the hosts machine
 - Validate if a Dockerfile is present in the project source, if one isn't specified by the devfile
 - Handle devfile v1 cases
 - Write lots of tests
 - More appropriate error/warning messages
