### PR TITLE
Download Dockerfile into memory

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -675,7 +675,7 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 		compInfo := common.ComponentInfo{
 			PodName: pod.Name,
 		}
-		err = sync.CopyFile(client, path, compInfo, targetPath, files, globExps)
+		err = sync.CopyFile(client, path, compInfo, targetPath, files, globExps, map[string][]byte{})
 		if err != nil {
 			s.End(false)
 			return errors.Wrap(err, "unable push files to pod")

--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -29,7 +29,7 @@ type Storage struct {
 // BuildParameters is a struct containing the parameters to be used when building the image for a devfile component
 type BuildParameters struct {
 	Path            string                  // Path refers to the parent folder containing the source code to push up to a component
-	DockerfilePath  string                  // DockerfilePath is the path to the Dockerfile downloaded, if one was provided by the devfile
+	DockerfileBytes []byte                  // DockerfileBytes is the contents of the project Dockerfile in bytes
 	EnvSpecificInfo envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
 	Tag             string                  // Tag refers to the image tag of the image being built
 	IgnoredFiles    []string                // IgnoredFiles is the list of files to not push up to a component

--- a/pkg/odo/cli/component/deploy.go
+++ b/pkg/odo/cli/component/deploy.go
@@ -71,7 +71,7 @@ func (do *DeployOptions) Validate() (err error) {
 		return errors.New("odo deploy requires a tag, in the format <registry>/namespace>/<image>")
 	}
 
-	err := util.ValidateTag(do.tag)
+	err = util.ValidateTag(do.tag)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -138,8 +138,8 @@ func (do *DeployOptions) DevfileBuild() (err error) {
 
 	buildParams := common.BuildParameters{
 		Path:            do.sourcePath,
-		DockerfilePath:  do.DockerfilePath,
 		Tag:             do.tag,
+		DockerfileBytes: do.DockerfileBytes,
 		EnvSpecificInfo: *do.EnvSpecificInfo,
 	}
 

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -31,7 +31,7 @@ type Adapter struct {
 	common.AdapterContext
 }
 
-// SyncsFilesBuild sync the local files to build container volume
+// SyncFilesBuild sync the local files to build container volume
 func (a Adapter) SyncFilesBuild(buildParameters common.BuildParameters, compInfo common.ComponentInfo) (syncFolder string, err error) {
 
 	// If we want to ignore any files
@@ -44,10 +44,8 @@ func (a Adapter) SyncFilesBuild(buildParameters common.BuildParameters, compInfo
 	syncFolder = "/projects"
 
 	s = log.Spinner("Checking files for deploy")
-	// run the indexer and find the modified/added/deleted/renamed files
-	files, _, err := util.RunIndexer(buildParameters.Path, absIgnoreRules)
-	// TODO just get all the files that obey to the absIgnoreRules (.odo, blah)
-
+	// run the indexer and find the project source files
+	files, err := util.DeployRunIndexer(buildParameters.Path, absIgnoreRules)
 	if len(files) > 0 {
 		klog.V(4).Infof("Copying files %s to pod", strings.Join(files, " "))
 		dockerfile := map[string][]byte{

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -43,10 +43,12 @@ func CopyFile(client SyncClient, localPath string, compInfo common.ComponentInfo
 			os.Exit(1)
 		}
 
+		// if the tar.Writer that was returned by makeTar is empty, declare a new one
 		if tarWriter == nil {
 			tarWriter = tar.NewWriter(writer)
 		}
 
+		// For each of the files passed, write them to the tar.Writer
 		for name, content := range copyBytes {
 			hdr := &tar.Header{
 				Name: name,
@@ -85,6 +87,9 @@ func checkFileExist(fileName string) bool {
 
 // makeTar function is copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp.go#L309
 // srcPath is ignored if files is set
+// makeTar returns a pointer to the tar.Writer, and doesn't close it during this function. The close is called outside
+// because in the case for copying source files, additional files are required to be written to it after this function has
+// already returned - meaning we can no longer defer the Close.
 func makeTar(srcPath, destPath string, writer io.Writer, files []string, globExps []string) (*tar.Writer, error) {
 	// TODO: use compression here?
 	tarWriter := tar.NewWriter(writer)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -39,7 +39,7 @@ func CopyFile(client SyncClient, localPath string, compInfo common.ComponentInfo
 
 		tarWriter := tar.NewWriter(writer)
 
-		err := makeTar(localPath, dest, writer, copyFiles, globExps, tarWriter)
+		err := makeTar(localPath, dest, copyFiles, globExps, tarWriter)
 		if err != nil {
 			log.Errorf("Error while creating tar: %#v", err)
 			os.Exit(1)
@@ -86,7 +86,7 @@ func checkFileExist(fileName string) bool {
 
 // makeTar function is copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp.go#L309
 // srcPath is ignored if files is set
-func makeTar(srcPath, destPath string, writer io.Writer, files []string, globExps []string, tarWriter *tar.Writer) error {
+func makeTar(srcPath, destPath string, files []string, globExps []string, tarWriter *tar.Writer) error {
 	// TODO: use compression here?
 
 	srcPath = filepath.Clean(srcPath)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -86,9 +86,6 @@ func checkFileExist(fileName string) bool {
 
 // makeTar function is copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp.go#L309
 // srcPath is ignored if files is set
-// makeTar returns a pointer to the tar.Writer, and doesn't close it during this function. The close is called outside
-// because in the case for copying source files, additional files are required to be written to it after this function has
-// already returned - meaning we can no longer defer the Close.
 func makeTar(srcPath, destPath string, writer io.Writer, files []string, globExps []string, tarWriter *tar.Writer) error {
 	// TODO: use compression here?
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1083,6 +1083,38 @@ func ValidateDockerfile(contents []byte) error {
 	return errors.Errorf("dockerfile URL provided in the Devfile does not point to a valid Dockerfile")
 }
 
+// ValidateTag validates the string that has been passed as a tag meets the requirements of a tag
+func ValidateTag(tag string) error {
+	var splitTag = strings.Split(tag, "/")
+	if len(splitTag) != 3 {
+		return errors.New("invalid tag: odo deploy reguires a tag in the format <registry>/namespace>/<image>")
+	}
+
+	// Valid characters for the registry, namespace, and image name
+	characterMatch := regexp.MustCompile(`[a-zA-Z0-9\.\-:_]{4,128}`)
+	for _, element := range splitTag {
+		if len(element) < 4 {
+			return errors.New("invalid tag: " + element + " in the tag is too short. Each element needs to be at least 4 characters.")
+		}
+
+		if len(element) > 128 {
+			return errors.New("invalid tag: " + element + " in the tag is too long. Each element cannot be longer than 128.")
+		}
+
+		// Check that the whole string matches the regular expression
+		// Match.String was returning a match even when only part of the string is working
+		if characterMatch.FindString(element) != element {
+			return errors.New("invalid tag: " + element + " in the tag contains an illegal character. It must only contain alphanumerical values, periods, colons, underscores, and dashes.")
+		}
+
+		// The registry, namespace, and image, cannot end in '.', '-', '_',or ':'
+		if strings.HasSuffix(element, ".") || strings.HasSuffix(element, "-") || strings.HasSuffix(element, ":") || strings.HasSuffix(element, "_") {
+			return errors.New("invalid tag: " + element + " in the tag has an invalid final character. It must end in an alphanumeric value.")
+		}
+	}
+	return nil
+}
+
 // sliceContainsString checks for existence of given string in given slice
 func sliceContainsString(str string, slice []string) bool {
 	for _, b := range slice {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1058,6 +1058,31 @@ func ValidateURL(sourceURL string) error {
 	return nil
 }
 
+// ValidateDockerfile validates the string passed through has a FROM on it's first non-whitespace/commented line
+// This function could be expanded to be a more viable linter
+func ValidateDockerfile(contents []byte) error {
+	// Split the file downloaded line-by-line
+	splitContents := strings.Split(string(contents), "\n")
+	// The first line in a Dockerfile must be a 'FROM', whitespace, or a comment ('#')
+	// If it there is whitespace, or there are comments, keep checking until we find either a FROM, or something else
+	// If there is something other than a FROM, the file downloaded wasn't a valid Dockerfile
+	for _, line := range splitContents {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "FROM") {
+			return nil
+		}
+		return errors.Errorf("dockerfile URL provided in the Devfile does not point to a valid Dockerfile")
+	}
+	// Would only reach this return statement if splitContents is 0
+	return errors.Errorf("dockerfile URL provided in the Devfile does not point to a valid Dockerfile")
+}
+
 // sliceContainsString checks for existence of given string in given slice
 func sliceContainsString(str string, slice []string) bool {
 	for _, b := range slice {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1778,3 +1778,80 @@ func TestValidateDockerfile(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTag(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want bool
+	}{
+		{
+			name: "Case 1: Valid tag ",
+			tag:  "image-registry.openshift-image-registry.svc:5000/default/my-nodejs:1.0",
+			want: true,
+		},
+		{
+			name: "Case 2: Invalid tag with trailing period",
+			tag:  "image-registry.openshift-image-registry.svc:5000./default/my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 3: Invalid tag with trailing dash",
+			tag:  "image-registry.openshift-image-registry.svc:5000-/default/my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 4: Invalid tag with trailing underscore",
+			tag:  "image-registry.openshift-image-registry.svc:5000_/default/my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 5: Invalid tag with trailing colon",
+			tag:  "image-registry.openshift-image-registry.svc:5000:/default/my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 6: Invalid tag with invalid characters",
+			tag:  "imag|||\\e-registry.openshift&^%-image-registry.svc:5000/default!/my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 7: Missing registry",
+			tag:  "/default/my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 8: Missing namespace",
+			tag:  "image-registry.openshift-image-registry.svc:5000//my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 9: Missing image",
+			tag:  "image-registry.openshift-image-registry.svc:5000/default/",
+			want: false,
+		},
+		{
+			name: "Case 10: Too many /'s",
+			tag:  "image-registry.openshift/image-registry.svc:5000:/default/my-nodejs:1.0",
+			want: false,
+		},
+		{
+			name: "Case 11: Too few /'s",
+			tag:  "image-registry.openshift-image-registry.svc:5000:/default-my-nodejs:1.0",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTag(tt.tag)
+
+			got := err == nil
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Got: %v, want: %v", got, tt.want)
+				t.Logf("Error message is: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1690,3 +1690,36 @@ func TestSliceContainsString(t *testing.T) {
 		})
 	}
 }
+
+func TestDownloadInMemory(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{
+			name: "Test download into memory with a valid URL",
+			url:  "https://github.com/openshift/odo/blob/master/tests/examples/source/devfiles/nodejs/devfile.yaml",
+			want: true,
+		},
+		{
+			name: "Test download into memory with an invalid URL",
+			url:  "https://this/is/not/a/valid/url",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DownloadFileInMemory(tt.url)
+
+			got := err == nil
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Got: %v, want: %v", got, tt.want)
+				t.Logf("Error message is: %v", err)
+			}
+		})
+	}
+}

--- a/tests/examples/source/devfilesV2/nodejs/devfile.yaml
+++ b/tests/examples/source/devfilesV2/nodejs/devfile.yaml
@@ -2,6 +2,7 @@ schemaVersion: "2.0.0"
 metadata:
   name: test-devfile
   dockerfile: "https://raw.githubusercontent.com/neeraj-laad/nodejs-stack-registry/build-deploy/devfiles/nodejs-basic/build/Dockerfile"
+  deployment-manifest: "https://raw.githubusercontent.com/groeges/devfile-registry/master/devfiles/nodejs/deploy.yaml"
 projects:
   - name: nodejs-web-app
     git: 

--- a/tests/examples/source/dockerfiles/Dockerfile
+++ b/tests/examples/source/dockerfiles/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:12
+
+COPY . /project/
+
+# Removing node_modules
+RUN rm -rf /project/node_modules
+
+# Install user-app dependencies
+WORKDIR /project
+RUN npm install --production 
+
+# Copy the dependencies into a slim Node docker image
+FROM node:12-slim
+
+# Copy project with dependencies
+COPY --chown=node:node --from=0 /project /project
+
+WORKDIR /project
+
+ENV NODE_ENV production
+
+USER node
+
+CMD ["npm", "start"]

--- a/tests/examples/source/dockerfiles/DockerfileInvalid
+++ b/tests/examples/source/dockerfiles/DockerfileInvalid
@@ -1,0 +1,26 @@
+Illegal Line
+
+FROM node:12
+
+COPY . /project/
+
+# Removing node_modules
+RUN rm -rf /project/node_modules
+
+# Install user-app dependencies
+WORKDIR /project
+RUN npm install --production 
+
+# Copy the dependencies into a slim Node docker image
+FROM node:12-slim
+
+# Copy project with dependencies
+COPY --chown=node:node --from=0 /project /project
+
+WORKDIR /project
+
+ENV NODE_ENV production
+
+USER node
+
+CMD ["npm", "start"]

--- a/tests/examples/source/dockerfiles/DockerfileInvalidFROM
+++ b/tests/examples/source/dockerfiles/DockerfileInvalidFROM
@@ -1,0 +1,24 @@
+FR0M node:12
+
+COPY . /project/
+
+# Removing node_modules
+RUN rm -rf /project/node_modules
+
+# Install user-app dependencies
+WORKDIR /project
+RUN npm install --production 
+
+# Copy the dependencies into a slim Node docker image
+FROM node:12-slim
+
+# Copy project with dependencies
+COPY --chown=node:node --from=0 /project /project
+
+WORKDIR /project
+
+ENV NODE_ENV production
+
+USER node
+
+CMD ["npm", "start"]

--- a/tests/examples/source/dockerfiles/DockerfileWithComment
+++ b/tests/examples/source/dockerfiles/DockerfileWithComment
@@ -1,0 +1,25 @@
+# Install the app dependencies in a full Node docker image
+FROM node:12
+
+COPY . /project/
+
+# Removing node_modules
+RUN rm -rf /project/node_modules
+
+# Install user-app dependencies
+WORKDIR /project
+RUN npm install --production 
+
+# Copy the dependencies into a slim Node docker image
+FROM node:12-slim
+
+# Copy project with dependencies
+COPY --chown=node:node --from=0 /project /project
+
+WORKDIR /project
+
+ENV NODE_ENV production
+
+USER node
+
+CMD ["npm", "start"]

--- a/tests/examples/source/dockerfiles/DockerfileWithWhitespace
+++ b/tests/examples/source/dockerfiles/DockerfileWithWhitespace
@@ -1,0 +1,28 @@
+
+     
+
+   
+   FROM node:12
+
+COPY . /project/
+
+# Removing node_modules
+RUN rm -rf /project/node_modules
+
+# Install user-app dependencies
+WORKDIR /project
+RUN npm install --production 
+
+# Copy the dependencies into a slim Node docker image
+FROM node:12-slim
+
+# Copy project with dependencies
+COPY --chown=node:node --from=0 /project /project
+
+WORKDIR /project
+
+ENV NODE_ENV production
+
+USER node
+
+CMD ["npm", "start"]

--- a/tests/integration/devfile/cmd_devfile_deploy_test.go
+++ b/tests/integration/devfile/cmd_devfile_deploy_test.go
@@ -1,0 +1,97 @@
+package devfile
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/odo/tests/helper"
+)
+
+var _ = Describe("odo devfile deploy command tests", func() {
+	var namespace, context, cmpName, currentWorkingDirectory, originalKubeconfig, imageTag string
+	// Using program commmand according to cliRunner in devfile
+	cliRunner := helper.GetCliRunner()
+
+	// This is run after every Spec (It)
+	var _ = BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+		context = helper.CreateNewContext()
+		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+
+		// Devfile push requires experimental mode to be set
+		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+
+		originalKubeconfig = os.Getenv("KUBECONFIG")
+		imageTag = "image-registry.openshift-image-registry.svc:5000/build-nodejs/image:1.0"
+		helper.LocalKubeconfigSet(context)
+		namespace = cliRunner.CreateRandNamespaceProject()
+		currentWorkingDirectory = helper.Getwd()
+		cmpName = helper.RandString(6)
+		helper.Chdir(context)
+	})
+
+	var _ = AfterEach(func() {
+		cliRunner.DeleteNamespaceProject(namespace)
+		helper.Chdir(currentWorkingDirectory)
+		err := os.Setenv("KUBECONFIG", originalKubeconfig)
+		Expect(err).NotTo(HaveOccurred())
+		helper.DeleteDir(context)
+		os.Unsetenv("GLOBALODOCONFIG")
+	})
+
+	Context("Verify dockerfile specified in devfile field points to valid Dockerfile", func() {
+		It("Should succesfully download the dockerfile and build the project", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV2", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			output := helper.CmdShouldPass("odo", "deploy", "--tag", imageTag, "--devfile", "devfile.yaml")
+			Expect(output).NotTo(ContainSubstring("does not point to a valid Dockerfile"))
+		})
+	})
+
+	Context("Verify error when dockerfile specified in devfile field points to a file that isn't a Dockerfile", func() {
+		It("Should error out with 'URL does not point to a valid Dockerfile'", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV2", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			err := helper.ReplaceDevfileField("devfile.yaml", "dockerfile", "https://google.com")
+			Expect(err).To(BeNil())
+
+			cmdOutput := helper.CmdShouldFail("odo", "deploy", "--tag", imageTag, "--devfile", "devfile.yaml")
+			Expect(cmdOutput).To(ContainSubstring("does not point to a valid Dockerfile"))
+		})
+	})
+
+	// Context("Verify error when dockerfile specified in devfile field points to a file that doesn't exist", func() {
+	// 	It("Should error out with 'unable to download Dockerfile from URL specified in devfile'", func() {
+	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfilesV2", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+	// 		err := helper.ReplaceDevfileField("devfile.yaml", "dockerfile", "https://invalid.url/should/not/pass")
+	// 		Expect(err).To(BeNil())
+
+	// 		cmdOutput := helper.CmdShouldFail("odo", "deploy", "--tag", imageTag, "--devfile", "devfile.yaml")
+	// 		Expect(cmdOutput).To(ContainSubstring("unable to download Dockerfile from URL specified in devfile"))
+	// 	})
+	// })
+
+	Context("Verify error when no Dockerfile exists in project and no 'dockerfile' specified in devfile", func() {
+		It("Should error out with 'dockerfile required for build.'", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			cmdOutput := helper.CmdShouldFail("odo", "deploy", "--tag", imageTag, "--devfile", "devfile.yaml")
+			Expect(cmdOutput).To(ContainSubstring("dockerfile required for build. No 'dockerfile' field found in devfile, or Dockerfile found in project directory"))
+		})
+	})
+
+	Context("Verify warning when Dockerfile is present in the project directory and has been specified in the Devfile", func() {
+		It("Should build the project using the Dockerfile specified in the devfile", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV2", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CmdShouldPass("touch", "Dockerfile")
+			helper.CmdShouldPass("odo", "deploy", "--tag", imageTag, "--devfile", "devfile.yaml")
+		})
+	})
+})

--- a/tests/integration/devfile/cmd_devfile_deploy_test.go
+++ b/tests/integration/devfile/cmd_devfile_deploy_test.go
@@ -42,7 +42,7 @@ var _ = Describe("odo devfile deploy command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
-	Context("Verify dockerfile specified in devfile field points to valid Dockerfile", func() {
+	Context("Verify deploy completes when passing a valid Dockerfile URL from the devfile", func() {
 		It("Should succesfully download the dockerfile and build the project", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "3000")
@@ -53,7 +53,7 @@ var _ = Describe("odo devfile deploy command tests", func() {
 		})
 	})
 
-	Context("Verify error when dockerfile specified in devfile field points to a file that isn't a Dockerfile", func() {
+	Context("Verify error when dockerfile specified in devfile field doesn't point to a valid Dockerfile", func() {
 		It("Should error out with 'URL does not point to a valid Dockerfile'", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "3000")
@@ -73,16 +73,6 @@ var _ = Describe("odo devfile deploy command tests", func() {
 			helper.CmdShouldPass("odo", "url", "create", "--port", "3000")
 			cmdOutput := helper.CmdShouldFail("odo", "deploy", "--tag", imageTag, "--devfile", "devfile.yaml")
 			Expect(cmdOutput).To(ContainSubstring("dockerfile required for build. No 'dockerfile' field found in devfile, or Dockerfile found in project directory"))
-		})
-	})
-
-	Context("Verify warning when Dockerfile is present in the project directory and has been specified in the Devfile", func() {
-		It("Should build the project using the Dockerfile specified in the devfile", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
-			helper.CmdShouldPass("odo", "url", "create", "--port", "3000")
-			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV2", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
-			helper.CmdShouldPass("touch", "Dockerfile")
-			helper.CmdShouldPass("odo", "deploy", "--tag", imageTag, "--devfile", "devfile.yaml")
 		})
 	})
 })


### PR DESCRIPTION
- Downloads Dockerfile into memory rather than onto the hosts machine
- Validates if a Dockerfile is present in the project source, if one isn't specified by the devfile
- Validates the contents of the Dockerfile (that there is a FROM on the first non-comment/non-whitespace line)
- Validates the tag passed as an arg conforms to the correct character-set
- Copies all project source files into the container rather than new/updated
- Additional Testing
- More appropriate error/warning messages