### PR TITLE
Updated ^C features to work with new deploy flow

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/openshift/odo/pkg/exec"
@@ -84,6 +86,10 @@ func (a Adapter) runBuildConfig(client *occlient.Client, parameters common.Build
 		Name: buildName,
 	}
 
+	controlC := make(chan os.Signal)
+	signal.Notify(controlC, os.Interrupt, syscall.SIGTERM)
+	go a.terminateBuild(controlC, client, commonObjectMeta)
+
 	_, err = client.CreateDockerBuildConfigWithBinaryInput(commonObjectMeta, dockerfilePath, parameters.Tag, []corev1.EnvVar{})
 	if err != nil {
 		return err
@@ -114,21 +120,30 @@ func (a Adapter) runBuildConfig(client *occlient.Client, parameters common.Build
 	var cmdOutput string
 	// This Go routine will automatically pipe the output from WaitForBuildToFinish to
 	// our logger.
-	go func() {
-		scanner := bufio.NewScanner(reader)
-		for scanner.Scan() {
-			line := scanner.Text()
+	// We pass the controlC os.Signal in order to output the logs within the terminateBuild
+	// function if the process is interrupted by the user performing a ^C. If we didn't pass it
+	// The Scanner would consume the log, and only output it if there was an err within this
+	// func.
+	go func(controlC chan os.Signal) {
+		select {
+		case <-controlC:
+			return
+		default:
+			scanner := bufio.NewScanner(reader)
+			for scanner.Scan() {
+				line := scanner.Text()
 
-			if log.IsDebug() {
-				_, err := fmt.Fprintln(os.Stdout, line)
-				if err != nil {
-					log.Errorf("Unable to print to stdout: %v", err)
+				if log.IsDebug() {
+					_, err := fmt.Fprintln(os.Stdout, line)
+					if err != nil {
+						log.Errorf("Unable to print to stdout: %v", err)
+					}
 				}
-			}
 
-			cmdOutput += fmt.Sprintln(line)
+				cmdOutput += fmt.Sprintln(line)
+			}
 		}
-	}()
+	}(controlC)
 
 	s := log.Spinner("Waiting for build to complete")
 	if err := client.WaitForBuildToFinish(bc.Name, writer); err != nil {
@@ -137,7 +152,20 @@ func (a Adapter) runBuildConfig(client *occlient.Client, parameters common.Build
 	}
 
 	s.End(true)
+	// Stop listening for a ^C so it doesnt perform terminateBuild during any later stages
+	signal.Stop(controlC)
 	return
+}
+
+func (a Adapter) terminateBuild(c chan os.Signal, client *occlient.Client, commonObjectMeta metav1.ObjectMeta) {
+	_ = <-c
+
+	log.Info("\nBuild process interrupted, terminating build, this might take a few seconds")
+	err := client.DeleteBuildConfig(commonObjectMeta)
+	if err != nil {
+		log.Info("\n", err.Error())
+	}
+	os.Exit(0)
 }
 
 // Build image for devfile project

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -157,6 +157,10 @@ func (a Adapter) runBuildConfig(client *occlient.Client, parameters common.Build
 	return
 }
 
+// terminateBuild is triggered if the user performs a ^C action within the terminal during the build phase
+// of the deploy.
+// It cleans up the resources created for the build, as the defer function would not be reached.
+// The subsequent deploy would fail if these resources are not cleaned up.
 func (a Adapter) terminateBuild(c chan os.Signal, client *occlient.Client, commonObjectMeta metav1.ObjectMeta) {
 	_ = <-c
 


### PR DESCRIPTION
Added functionality for if/when the user cancels out of the deploy via ^C on the command line during the build phase, the build resources will now be deleted. 
This is done in the defer function for when the build stage is completed regardless of pass or fail, but killing the process currently leaves resources which need to be manually deleted before the user can do another odo deploy.