### PR TITLE
Add check for valid URL/PORT in env.yaml if PORT defined in manifest

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -40,6 +40,7 @@ type DeployParameters struct {
 	EnvSpecificInfo envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
 	Tag             string                  // Tag refers to the image tag of the image being built
 	ManifestSource  []byte                  // Source of the manifest file
+	DeploymentPort  int                     // Port to be used in deployment manifest
 }
 
 // PushParameters is a struct containing the parameters to be used when pushing to a devfile component

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -191,11 +191,10 @@ func (a Adapter) Build(parameters common.BuildParameters) (err error) {
 	return errors.New("unable to build image, only Openshift BuildConfig build is supported")
 }
 
-func determinePort(envSpecificInfo envinfo.EnvSpecificInfo) string {
+func determinePort(envSpecificInfo envinfo.EnvSpecificInfo) (deploymentPort string) {
 	// Determine port to use from first non-Docker route in env.yaml)
-	deploymentPort := ""
 	for _, localURL := range envSpecificInfo.GetURL() {
-		if localURL.Kind != envinfo.DOCKER {
+		if localURL.Kind == envinfo.ROUTE {
 			deploymentPort = strconv.Itoa(localURL.Port)
 			break
 		}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -33,7 +33,6 @@ import (
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes/storage"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes/utils"
 	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
-	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
@@ -191,17 +190,6 @@ func (a Adapter) Build(parameters common.BuildParameters) (err error) {
 	return errors.New("unable to build image, only Openshift BuildConfig build is supported")
 }
 
-func determinePort(envSpecificInfo envinfo.EnvSpecificInfo) (deploymentPort string) {
-	// Determine port to use from first non-Docker route in env.yaml)
-	for _, localURL := range envSpecificInfo.GetURL() {
-		if localURL.Kind == envinfo.ROUTE {
-			deploymentPort = strconv.Itoa(localURL.Port)
-			break
-		}
-	}
-	return deploymentPort
-}
-
 func substitueYamlVariables(baseYaml []byte, yamlSubstitutions map[string]string) []byte {
 	// TODO: Provide a better way to do the substitution in the manifest file(s)
 	for key, value := range yamlSubstitutions {
@@ -285,7 +273,7 @@ func (a Adapter) Deploy(parameters common.DeployParameters) (err error) {
 	yamlSubstitutions := map[string]string{
 		"CONTAINER_IMAGE": parameters.Tag,
 		"COMPONENT_NAME":  applicationName,
-		"PORT":            determinePort(parameters.EnvSpecificInfo),
+		"PORT":            strconv.Itoa(parameters.DeploymentPort),
 	}
 
 	// Build a yaml decoder with the unstructured Scheme

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -1,6 +1,7 @@
 package envinfo
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -295,6 +296,16 @@ func (ei *EnvInfo) GetDebugPort() int {
 		return DefaultDebugPort
 	}
 	return *ei.componentSettings.DebugPort
+}
+
+// GetPortByURLKind returns the Port of a specific URL type, returns 0 if nil
+func (ei *EnvInfo) GetPortByURLKind(urlKind URLKind) (int, error) {
+	for _, localURL := range ei.GetURL() {
+		if localURL.Kind == urlKind {
+			return localURL.Port, nil
+		}
+	}
+	return 0, errors.New(fmt.Sprintf("unable to find port for URL of kind: '%s'", urlKind))
 }
 
 // GetNamespace returns component namespace

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -175,6 +175,7 @@ func (do *DeployOptions) DevfileDeploy() (err error) {
 		EnvSpecificInfo: *do.EnvSpecificInfo,
 		Tag:             do.tag,
 		ManifestSource:  do.ManifestSource,
+		DeploymentPort:  do.DeploymentPort,
 	}
 
 	warnIfURLSInvalid(do.EnvSpecificInfo.GetURL())

--- a/tests/examples/source/manifests/deploy_deployment_no_port_substitution.yaml
+++ b/tests/examples/source/manifests/deploy_deployment_no_port_substitution.yaml
@@ -1,0 +1,60 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: COMPONENT_NAME
+  labels:
+    app.kubernetes.io/instance: COMPONENT_NAME
+    app.kubernetes.io/name: COMPONENT_NAME
+    app.kubernetes.io/part-of: COMPONENT_NAME
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: COMPONENT_NAME
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: COMPONENT_NAME
+    spec:
+      containers:
+        - name: COMPONENT_NAME
+          image: CONTAINER_IMAGE
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: COMPONENT_NAME
+spec:
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+  selector:
+    app: COMPONENT_NAME
+  type: ClusterIP
+  sessionAffinity: None
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: COMPONENT_NAME
+  labels:
+    app.kubernetes.io/instance: COMPONENT_NAME
+    app.kubernetes.io/name: COMPONENT_NAME
+    app.kubernetes.io/part-of: COMPONENT_NAME
+  annotations:
+    openshift.io/host.generated: 'true'
+spec:
+  to:
+    kind: Service
+    name: COMPONENT_NAME
+    weight: 100
+  port:
+    targetPort: 3000
+  wildcardPolicy: None


### PR DESCRIPTION
Signed-off-by: Steven Groeger <groeges@uk.ibm.com>

**What type of PR is this?**
/kind bug

> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
If there is a PORT substitution variable in the deployment-manifest being used, then check there is a valid URL with PORT defined in env.yaml (as a result of running `odo url create`). If not, then fail with suitable error.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
